### PR TITLE
Use v1 for LocalObjectReference.

### DIFF
--- a/pkg/api/v1alpha1/image_policy.go
+++ b/pkg/api/v1alpha1/image_policy.go
@@ -1,10 +1,9 @@
 package v1alpha1
 
 import (
-	corev1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/kubernetes/pkg/apis/core"
 )
 
 // ImagePolicy describes the configuration options for the ImagePolicy.
@@ -27,10 +26,10 @@ type ImagePolicyList struct {
 
 // ImagePolicySpec describes the specification for Image.
 type ImagePolicySpec struct {
-	Image            string                        `json:"image"`
-	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets"`
-	ImagePullPolicy  *corev1.PullPolicy            `json:"imagePullPolicy"`
-	VersioningPolicy core.LocalObjectReference     `json:"versioningPolicy"`
+	Image            string                    `json:"image"`
+	ImagePullSecrets []v1.LocalObjectReference `json:"imagePullSecrets"`
+	ImagePullPolicy  *v1.PullPolicy            `json:"imagePullPolicy"`
+	VersioningPolicy v1.LocalObjectReference   `json:"versioningPolicy"`
 }
 
 // ImagePolicyStatus represents the latest version of the ImagePolicy that

--- a/pkg/api/v1alpha1/microservice.go
+++ b/pkg/api/v1alpha1/microservice.go
@@ -1,9 +1,9 @@
 package v1alpha1
 
 import (
+	"k8s.io/api/core/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	core "k8s.io/kubernetes/pkg/apis/core"
 )
 
 // Microservice represents the definition which we'll use to define a deployable
@@ -28,10 +28,10 @@ type MicroserviceList struct {
 // MicroserviceSpec represents the specification for a Microservice. It houses
 // all the policies which we'll use to build a VersionedMicroservice.
 type MicroserviceSpec struct {
-	ImagePolicy        core.LocalObjectReference `json:"imagePolicy"`
-	AvailabilityPolicy core.LocalObjectReference `json:"availabilityPolicy,omitempty"`
-	ConfigPolicy       core.LocalObjectReference `json:"configPolicy,omitempty"`
-	SecurityPolicy     core.LocalObjectReference `json:"securityPolicy,omitempty"`
+	ImagePolicy        v1.LocalObjectReference `json:"imagePolicy"`
+	AvailabilityPolicy v1.LocalObjectReference `json:"availabilityPolicy,omitempty"`
+	ConfigPolicy       v1.LocalObjectReference `json:"configPolicy,omitempty"`
+	SecurityPolicy     v1.LocalObjectReference `json:"securityPolicy,omitempty"`
 }
 
 // MicroserviceStatus represents the status a specific Microservice is in.


### PR DESCRIPTION
Core doesn't specify how the value should be translated, whilst v1 does.
We should use the v1 version.