### PR TITLE
Prevent feedbackloop in ghr controller

### DIFF
--- a/pkg/githubrepository/controller.go
+++ b/pkg/githubrepository/controller.go
@@ -176,6 +176,12 @@ func (c *Controller) syncPolicy(obj interface{}) error {
 		return err
 	}
 
+	wh := ghp.Status.Webhook
+	if wh != nil && wh.ID != nil && *wh.ID == *hook.ID && wh.Secret == hook.Secret {
+		// no change needed
+		return nil
+	}
+
 	// need to specify types again until we resolve the mapping issue
 	ghp.TypeMeta = metav1.TypeMeta{
 		Kind:       "GitHubRepository",


### PR DESCRIPTION
If we continually patch for updates to the webhook, the controller will
keep seeing this as a change, and attempt to reconcile again. Skip
patching when no change occurs to the webhook.