### PR TITLE
Make the NetworkPolicy Status URL fully qualified.

### DIFF
--- a/pkg/networkpolicy/network_status.go
+++ b/pkg/networkpolicy/network_status.go
@@ -1,6 +1,10 @@
 package networkpolicy
 
-import "github.com/manifoldco/heighliner/pkg/api/v1alpha1"
+import (
+	"fmt"
+
+	"github.com/manifoldco/heighliner/pkg/api/v1alpha1"
+)
 
 func buildNetworkStatusForRelease(np *v1alpha1.NetworkPolicy, release *v1alpha1.Release) (v1alpha1.NetworkPolicyStatus, error) {
 
@@ -10,10 +14,20 @@ func buildNetworkStatusForRelease(np *v1alpha1.NetworkPolicy, release *v1alpha1.
 
 	for _, record := range np.Spec.ExternalDNS {
 		domain := v1alpha1.Domain{
-			URL: record.Domain, SemVer: release.SemVer,
+			URL:    getFullURL(record),
+			SemVer: release.SemVer,
 		}
 		ns.Domains = append(ns.Domains, domain)
 	}
 
 	return ns, nil
+}
+
+func getFullURL(dns v1alpha1.ExternalDNS) string {
+	scheme := "https://"
+	if dns.DisableTLS {
+		scheme = "http://"
+	}
+
+	return fmt.Sprintf("%s%s", scheme, dns.Domain)
 }

--- a/pkg/networkpolicy/network_status_test.go
+++ b/pkg/networkpolicy/network_status_test.go
@@ -1,6 +1,7 @@
 package networkpolicy
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/manifoldco/heighliner/pkg/api/v1alpha1"
@@ -30,7 +31,7 @@ func TestNetworkStatus(t *testing.T) {
 		}
 
 		actualDomainURL := status.Domains[0].URL
-		expectedDomainURL := "my.cool.domain"
+		expectedDomainURL := "https://my.cool.domain"
 		if actualDomainURL != expectedDomainURL {
 			t.Errorf("Expected domain URL to be %s, got '%s'", expectedDomainURL, actualDomainURL)
 		}
@@ -57,16 +58,45 @@ func TestNetworkStatus(t *testing.T) {
 		}
 
 		actualFirstDomainURL := status.Domains[0].URL
-		expectedFirstDomainURL := "my.cool.domain"
+		expectedFirstDomainURL := "https://my.cool.domain"
 		if actualFirstDomainURL != expectedFirstDomainURL {
 			t.Errorf("Expected domain URL to be %s, got '%s'", expectedFirstDomainURL, actualFirstDomainURL)
 		}
 
 		actualSecondDomainURL := status.Domains[1].URL
-		expectedSecondDomainURL := "my.other.cool.domain"
+		expectedSecondDomainURL := "https://my.other.cool.domain"
 		if actualSecondDomainURL != expectedSecondDomainURL {
 			t.Errorf("Expected domain URL to be %s, got '%s'", expectedSecondDomainURL, actualSecondDomainURL)
 		}
 
+	})
+}
+
+func TestFullDomain(t *testing.T) {
+	t.Run("without TLS disabled", func(t *testing.T) {
+		domain := "my.cool.domain"
+		url := fmt.Sprintf("https://%s", domain)
+
+		dns := v1alpha1.ExternalDNS{
+			Domain: domain,
+		}
+
+		if actual := getFullURL(dns); actual != url {
+			t.Errorf("Expected url to be '%s', got '%s'", url, actual)
+		}
+	})
+
+	t.Run("with TLS disabled", func(t *testing.T) {
+		domain := "my.cool.domain"
+		url := fmt.Sprintf("http://%s", domain)
+
+		dns := v1alpha1.ExternalDNS{
+			Domain:     domain,
+			DisableTLS: true,
+		}
+
+		if actual := getFullURL(dns); actual != url {
+			t.Errorf("Expected url to be '%s', got '%s'", url, actual)
+		}
 	})
 }


### PR DESCRIPTION
This makes the Status URL on the NetworkPolicy CRDs fully qualified,
making the status an absolute truth which can be used within other parts
of the system.

```
  status:
    domains:
    - semVer:
        name: test-pr
        version: 3437bc31963ee582cdd640dea0035220e55ae2e9
      url: http://hlnr-www.arigato.tools
```