### PR TITLE
Handle errors and vsvc deletes properly.

### DIFF
--- a/pkg/api/v1alpha1/release.go
+++ b/pkg/api/v1alpha1/release.go
@@ -105,7 +105,6 @@ func (r *SemVerRelease) fullName() string {
 // ReleaseValidationSchema represents the OpenAPIv3 validation schema for a
 // release object.
 var ReleaseValidationSchema = v1beta1.JSONSchemaProps{
-	Required: []string{"releases"},
 	Properties: map[string]v1beta1.JSONSchemaProps{
 		"releases": {
 			Required: []string{"semVer", "image", "released"},

--- a/pkg/svc/controller.go
+++ b/pkg/svc/controller.go
@@ -2,7 +2,6 @@ package svc
 
 import (
 	"context"
-	"errors"
 	"log"
 	"os"
 	"os/signal"
@@ -266,10 +265,6 @@ func (c *Controller) getImagePolicy(crd *v1alpha1.Microservice) (*v1alpha1.Image
 	ipName := crd.Spec.ImagePolicy.Name
 	if err := c.patcher.Get(imagePolicy, crd.Namespace, ipName); err != nil {
 		return nil, err
-	}
-
-	if len(imagePolicy.Status.Releases) == 0 {
-		return nil, errors.New("Need a release to be set in the ImagePolicy Status")
 	}
 
 	return imagePolicy, nil


### PR DESCRIPTION
If we ignore errors that occur, the Microservice Status will get into a
dirty state. We can't just ignore these.

This patch also fixes an issue where we didn't set up the Namespace for
a VersionedMicroservice which we want to delete accordingly.