### PR TITLE
Fill in templated data correctly for status URLs.

### DIFF
--- a/pkg/networkpolicy/controller.go
+++ b/pkg/networkpolicy/controller.go
@@ -189,7 +189,7 @@ func syncSelectedRelease(cl patchClient, ms *v1alpha1.Microservice, networkPolic
 		return err
 	}
 
-	status, err := buildNetworkStatusForRelease(np, externalRelease)
+	status, err := buildNetworkStatusForRelease(ms, np, externalRelease)
 	if err != nil {
 		log.Printf("Error building Network Status for release %s: %s", name, err)
 		return err

--- a/pkg/networkpolicy/network_status.go
+++ b/pkg/networkpolicy/network_status.go
@@ -6,15 +6,20 @@ import (
 	"github.com/manifoldco/heighliner/pkg/api/v1alpha1"
 )
 
-func buildNetworkStatusForRelease(np *v1alpha1.NetworkPolicy, release *v1alpha1.Release) (v1alpha1.NetworkPolicyStatus, error) {
-
+func buildNetworkStatusForRelease(ms *v1alpha1.Microservice, np *v1alpha1.NetworkPolicy, release *v1alpha1.Release) (v1alpha1.NetworkPolicyStatus, error) {
 	ns := v1alpha1.NetworkPolicyStatus{
 		Domains: []v1alpha1.Domain{},
 	}
 
 	for _, record := range np.Spec.ExternalDNS {
+		url, err := templatedDomain(ms, release, getFullURL(record))
+		if err != nil {
+			// XXX: handle gracefully
+			panic(err)
+		}
+
 		domain := v1alpha1.Domain{
-			URL:    getFullURL(record),
+			URL:    url,
 			SemVer: release.SemVer,
 		}
 		ns.Domains = append(ns.Domains, domain)

--- a/pkg/networkpolicy/network_status_test.go
+++ b/pkg/networkpolicy/network_status_test.go
@@ -14,6 +14,8 @@ func TestNetworkStatus(t *testing.T) {
 		},
 	}
 
+	ms := &v1alpha1.Microservice{}
+
 	t.Run("with a single domain network policy", func(t *testing.T) {
 		np := &v1alpha1.NetworkPolicy{
 			Spec: v1alpha1.NetworkPolicySpec{
@@ -25,7 +27,7 @@ func TestNetworkStatus(t *testing.T) {
 			},
 		}
 
-		status, _ := buildNetworkStatusForRelease(np, release)
+		status, _ := buildNetworkStatusForRelease(ms, np, release)
 		if len(status.Domains) != 1 {
 			t.Errorf("Expected status domains to be of length 1, got '%d'", len(status.Domains))
 		}
@@ -52,7 +54,7 @@ func TestNetworkStatus(t *testing.T) {
 			},
 		}
 
-		status, _ := buildNetworkStatusForRelease(np, release)
+		status, _ := buildNetworkStatusForRelease(ms, np, release)
 		if len(status.Domains) != 2 {
 			t.Errorf("Expected status domains to be of length 2, got '%d'", len(status.Domains))
 		}


### PR DESCRIPTION
The NetworkStatus stores it's own URLs. If this is a templated URL, we
need to resolve it correctly.