### PR TITLE
ObjectReference instead of LocalObjectReference.

### DIFF
--- a/pkg/api/v1alpha1/github_repository.go
+++ b/pkg/api/v1alpha1/github_repository.go
@@ -83,10 +83,10 @@ type GitHubRelease struct {
 // Deployment represents a linking between a GitHub deployment and a network
 // policy. Through the release information we can determine a specific domain.
 type Deployment struct {
-	ID            *int64                      `json:"deployment"`
-	NetworkPolicy corev1.LocalObjectReference `json:"networkPolicy"`
-	State         string                      `json:"state"`
-	URL           *string                     `json:"url,omitempty"`
+	ID            *int64                 `json:"deployment"`
+	NetworkPolicy corev1.ObjectReference `json:"networkPolicy"`
+	State         string                 `json:"state"`
+	URL           *string                `json:"url,omitempty"`
 }
 
 // GitHubRepositoryValidationSchema represents the OpenAPIV3Schema

--- a/pkg/api/v1alpha1/image_policy.go
+++ b/pkg/api/v1alpha1/image_policy.go
@@ -29,7 +29,7 @@ type ImagePolicySpec struct {
 	Image            string                    `json:"image"`
 	ImagePullSecrets []v1.LocalObjectReference `json:"imagePullSecrets"`
 	ImagePullPolicy  *v1.PullPolicy            `json:"imagePullPolicy"`
-	VersioningPolicy v1.LocalObjectReference   `json:"versioningPolicy"`
+	VersioningPolicy v1.ObjectReference        `json:"versioningPolicy"`
 	Filter           ImagePolicyFilter         `json:"filter"`
 }
 
@@ -43,7 +43,7 @@ type ImagePolicyStatus struct {
 
 // ImagePolicyFilter will define how we can filter where images come from
 type ImagePolicyFilter struct {
-	GitHub *v1.LocalObjectReference `json:"github,omitempty"`
+	GitHub *v1.ObjectReference `json:"github,omitempty"`
 }
 
 // ImagePolicyValidationSchema represents the OpenAPIV3Schema validation for

--- a/pkg/api/v1alpha1/microservice.go
+++ b/pkg/api/v1alpha1/microservice.go
@@ -28,11 +28,14 @@ type MicroserviceList struct {
 // MicroserviceSpec represents the specification for a Microservice. It houses
 // all the policies which we'll use to build a VersionedMicroservice.
 type MicroserviceSpec struct {
-	ImagePolicy        v1.LocalObjectReference `json:"imagePolicy"`
-	AvailabilityPolicy v1.LocalObjectReference `json:"availabilityPolicy,omitempty"`
-	ConfigPolicy       v1.LocalObjectReference `json:"configPolicy,omitempty"`
-	SecurityPolicy     v1.LocalObjectReference `json:"securityPolicy,omitempty"`
-	HealthPolicy       v1.LocalObjectReference `json:"healthPolicy,omitempty"`
+	// Local object references, microservice specific
+	ImagePolicy  v1.LocalObjectReference `json:"imagePolicy"`
+	ConfigPolicy v1.LocalObjectReference `json:"configPolicy,omitempty"`
+
+	// Global Object References, not Microservice specific.
+	AvailabilityPolicy v1.ObjectReference `json:"availabilityPolicy,omitempty"`
+	SecurityPolicy     v1.ObjectReference `json:"securityPolicy,omitempty"`
+	HealthPolicy       v1.ObjectReference `json:"healthPolicy,omitempty"`
 }
 
 // MicroserviceStatus represents the status a specific Microservice is in.

--- a/pkg/api/v1alpha1/zz_generated.go
+++ b/pkg/api/v1alpha1/zz_generated.go
@@ -645,7 +645,7 @@ func (in *ImagePolicyFilter) DeepCopyInto(out *ImagePolicyFilter) {
 		if *in == nil {
 			*out = nil
 		} else {
-			*out = new(v1.LocalObjectReference)
+			*out = new(v1.ObjectReference)
 			**out = **in
 		}
 	}
@@ -856,8 +856,8 @@ func (in *MicroserviceList) DeepCopyObject() runtime.Object {
 func (in *MicroserviceSpec) DeepCopyInto(out *MicroserviceSpec) {
 	*out = *in
 	out.ImagePolicy = in.ImagePolicy
-	out.AvailabilityPolicy = in.AvailabilityPolicy
 	out.ConfigPolicy = in.ConfigPolicy
+	out.AvailabilityPolicy = in.AvailabilityPolicy
 	out.SecurityPolicy = in.SecurityPolicy
 	out.HealthPolicy = in.HealthPolicy
 	return

--- a/pkg/githubrepository/controller.go
+++ b/pkg/githubrepository/controller.go
@@ -413,7 +413,10 @@ func (c *Controller) syncDeployment(obj interface{}, deleted bool) {
 	}
 
 	// Fix the network policy reference. reconciliation doesn't care about it.
-	npr := v1.LocalObjectReference{Name: np.Name}
+	npr := v1.ObjectReference{
+		Name:      np.Name,
+		Namespace: np.Namespace,
+	}
 	for i := range newReleases {
 		if newReleases[i].Deployment != nil {
 			newReleases[i].Deployment.NetworkPolicy = npr

--- a/pkg/imagepolicy/controller.go
+++ b/pkg/imagepolicy/controller.go
@@ -156,7 +156,13 @@ func getGithubRepository(cl patchClient, ip *v1alpha1.ImagePolicy) (*v1alpha1.Gi
 		},
 	}
 
-	if err := cl.Get(githubRepository, ip.Namespace, ip.Spec.Filter.GitHub.Name); err != nil {
+	ghName := ip.Spec.Filter.GitHub.Name
+	ghNamespace := ip.Spec.Filter.GitHub.Name
+	if ghNamespace == "" {
+		ghNamespace = ip.Namespace
+	}
+
+	if err := cl.Get(githubRepository, ghNamespace, ghName); err != nil {
 		return nil, err
 	}
 

--- a/pkg/imagepolicy/controller_test.go
+++ b/pkg/imagepolicy/controller_test.go
@@ -57,7 +57,7 @@ func TestFilterImages(t *testing.T) {
 				Spec: v1alpha1.ImagePolicySpec{
 					Image: "manifoldco/heighliner",
 					Filter: v1alpha1.ImagePolicyFilter{
-						GitHub: &v1.LocalObjectReference{
+						GitHub: &v1.ObjectReference{
 							Name: "github.com/manifoldco/heighliner",
 						},
 					},

--- a/pkg/svc/controller.go
+++ b/pkg/svc/controller.go
@@ -282,7 +282,12 @@ func (c *Controller) getAvailabilityPolicySpec(crd *v1alpha1.Microservice) (*v1a
 		return nil, nil
 	}
 
-	if err := c.patcher.Get(availabilityPolicy, crd.Namespace, apName); err != nil {
+	apNamespace := crd.Spec.AvailabilityPolicy.Namespace
+	if apName == "" {
+		apNamespace = crd.Namespace
+	}
+
+	if err := c.patcher.Get(availabilityPolicy, apNamespace, apName); err != nil {
 		return nil, err
 	}
 
@@ -324,12 +329,17 @@ func (c *Controller) getSecurityPolicySpec(crd *v1alpha1.Microservice) (*v1alpha
 		},
 	}
 
-	apName := crd.Spec.SecurityPolicy.Name
-	if apName == "" {
+	spName := crd.Spec.SecurityPolicy.Name
+	if spName == "" {
 		return nil, nil
 	}
 
-	if err := c.patcher.Get(securityPolicy, crd.Namespace, apName); err != nil {
+	spNamespace := crd.Spec.SecurityPolicy.Namespace
+	if spNamespace == "" {
+		spNamespace = crd.Namespace
+	}
+
+	if err := c.patcher.Get(securityPolicy, spNamespace, spName); err != nil {
 		return nil, err
 	}
 
@@ -349,7 +359,12 @@ func (c *Controller) getHealthPolicySpec(crd *v1alpha1.Microservice) (*v1alpha1.
 		return nil, nil
 	}
 
-	if err := c.patcher.Get(healthPolicy, crd.Namespace, apName); err != nil {
+	hpNamespace := crd.Spec.HealthPolicy.Namespace
+	if hpNamespace == "" {
+		hpNamespace = crd.Namespace
+	}
+
+	if err := c.patcher.Get(healthPolicy, hpNamespace, apName); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Some policies can be shared across multiple environments. We should
allow users to specify this as such.

By using `ObjectReference` instead of `LocalObjectReference`, a user can
define the namespace an object lives in. This is useful for fetching
data across multiple namespaces.

The caveat here is that with RBAC enabled, users must set up access
properly.