### PR TITLE
Fix up ownership of services and ingress

### DIFF
--- a/pkg/networkpolicy/service.go
+++ b/pkg/networkpolicy/service.go
@@ -5,58 +5,54 @@ import (
 	"github.com/manifoldco/heighliner/pkg/k8sutils"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func buildServiceForRelease(svc *v1alpha1.Microservice, np *v1alpha1.NetworkPolicy, release *v1alpha1.Release, versioned bool) (*corev1.Service, error) {
-	if len(np.Spec.Ports) == 0 {
-		return nil, nil
-	}
-
-	name := svc.Name
-	if versioned {
-		name = release.FullName(svc.Name)
-	}
-
+func buildServiceForRelease(srv *corev1.Service, svc *v1alpha1.Microservice, np *v1alpha1.NetworkPolicy, release *v1alpha1.Release) *corev1.Service {
 	labels := k8sutils.Labels(np.Labels, np.ObjectMeta)
 	labels["hlnr.io/microservice.full_name"] = release.FullName(svc.Name)
 	labels["hlnr.io/microservice.name"] = svc.Name
 	labels["hlnr.io/microservice.release"] = release.Name()
 	labels["hlnr.io/microservice.version"] = release.Version()
 
-	selector := labels
-	delete(selector, k8sutils.LabelServiceKey)
+	if srv.Labels == nil {
+		srv.Labels = labels
+	} else {
+		// maintain any existing labels, adding our new ones
+		for k, v := range labels {
+			srv.Labels[k] = v
+		}
+	}
 
 	annotations := k8sutils.Annotations(np.Annotations, v1alpha1.Version, np)
+	if srv.Annotations == nil {
+		srv.Annotations = annotations
+	} else {
+		// maintain any existing annotations, adding our new ones
+		for k, v := range annotations {
+			srv.Annotations[k] = v
+		}
+	}
+
+	selector := make(map[string]string)
+	for k, v := range labels {
+		selector[k] = v
+	}
+	delete(selector, k8sutils.LabelServiceKey)
 
 	sessionAffinity := corev1.ServiceAffinityNone
 	if np.Spec.SessionAffinity != nil && np.Spec.SessionAffinity.ClientIP != nil {
 		sessionAffinity = corev1.ServiceAffinityClientIP
 	}
 
-	return &corev1.Service{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Service",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			// TODO(jelmer): we'll want a hashed name here based on timestamp
-			// etc.
-			Name:            name,
-			Namespace:       svc.Namespace,
-			Labels:          labels,
-			Annotations:     annotations,
-			OwnerReferences: release.OwnerReferences,
-		},
-		Spec: corev1.ServiceSpec{
-			Type:                  corev1.ServiceTypeNodePort,
-			Ports:                 getServicePorts(np.Spec.Ports),
-			Selector:              selector,
-			SessionAffinity:       sessionAffinity,
-			SessionAffinityConfig: np.Spec.SessionAffinity,
-		},
-	}, nil
+	srv.OwnerReferences = release.OwnerReferences
+	srv.Spec.Type = corev1.ServiceTypeNodePort
+	srv.Spec.Ports = getServicePorts(np.Spec.Ports)
+	srv.Spec.Selector = selector
+	srv.Spec.SessionAffinity = sessionAffinity
+	srv.Spec.SessionAffinityConfig = np.Spec.SessionAffinity
+
+	return srv
 }
 
 func getServicePorts(networkPorts []v1alpha1.NetworkPort) []corev1.ServicePort {

--- a/pkg/networkpolicy/service_test.go
+++ b/pkg/networkpolicy/service_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/manifoldco/heighliner/pkg/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -22,41 +23,63 @@ func TestBuildServiceForRelease(t *testing.T) {
 		},
 	}
 
-	t.Run("without ports", func(t *testing.T) {
-		np := &v1alpha1.NetworkPolicy{
-			Spec: v1alpha1.NetworkPolicySpec{},
-		}
-
-		obj, err := buildServiceForRelease(ms, np, release, true)
-		if obj != nil {
-			t.Errorf("Expected object to be nil, got %#v", obj)
-		}
-
-		if err != nil {
-			t.Errorf("Expected error to be nil, got %s", err)
-		}
-	})
-
-	t.Run("with a set of ports", func(t *testing.T) {
-		np := &v1alpha1.NetworkPolicy{
-			Spec: v1alpha1.NetworkPolicySpec{
-				Ports: []v1alpha1.NetworkPort{
-					{
-						Name:       "headless",
-						TargetPort: 8080,
-						Port:       80,
-					},
+	np := &v1alpha1.NetworkPolicy{
+		Spec: v1alpha1.NetworkPolicySpec{
+			Ports: []v1alpha1.NetworkPort{
+				{
+					Name:       "headless",
+					TargetPort: 8080,
+					Port:       80,
 				},
 			},
-		}
+		},
+	}
 
-		obj, err := buildServiceForRelease(ms, np, release, true)
+	t.Run("with a set of ports", func(t *testing.T) {
+		srv := &corev1.Service{}
+
+		obj := buildServiceForRelease(srv, ms, np, release)
 		if obj == nil {
-			t.Errorf("Expected object to be nil, got %#v", obj)
-		}
-
-		if err != nil {
-			t.Errorf("Expected error to be nil, got %s", err)
+			t.Error("Expected object to not be nil")
 		}
 	})
+
+	t.Run("Maintains existing labels", func(t *testing.T) {
+		srv := &corev1.Service{}
+		srv.Labels = map[string]string{
+			"dummy-label": "value",
+		}
+
+		obj := buildServiceForRelease(srv, ms, np, release)
+		if obj.Labels["dummy-label"] != "value" {
+			t.Error("Expected object to maintain existing label")
+		}
+	})
+
+	t.Run("Maintains existing annotations", func(t *testing.T) {
+		srv := &corev1.Service{}
+		srv.Annotations = map[string]string{
+			"dummy-annotation": "value",
+		}
+
+		obj := buildServiceForRelease(srv, ms, np, release)
+		if obj.Annotations["dummy-annotation"] != "value" {
+			t.Error("Expected object to maintain existing annotation")
+		}
+	})
+
+	t.Run("Sets client IP session affinity", func(t *testing.T) {
+		srv := &corev1.Service{}
+
+		np = np.DeepCopy()
+		np.Spec.SessionAffinity = &corev1.SessionAffinityConfig{
+			ClientIP: &corev1.ClientIPConfig{},
+		}
+
+		obj := buildServiceForRelease(srv, ms, np, release)
+		if obj.Spec.SessionAffinity != corev1.ServiceAffinityClientIP {
+			t.Error("Expected service to have client ip session affinity")
+		}
+	})
+
 }


### PR DESCRIPTION
Have the ingress be owned by the service (which won't change).

Ensure that services are replaced rather than patched, so there is only
one owner.