### PR TITLE
Make NetworkPolicyStatus aware of multiple release groups

### DIFF
--- a/pkg/networkpolicy/network_status_test.go
+++ b/pkg/networkpolicy/network_status_test.go
@@ -27,12 +27,12 @@ func TestNetworkStatus(t *testing.T) {
 			},
 		}
 
-		status, _ := buildNetworkStatusForRelease(ms, np, release)
-		if len(status.Domains) != 1 {
-			t.Errorf("Expected status domains to be of length 1, got '%d'", len(status.Domains))
+		domains, _ := buildNetworkStatusDomainsForRelease(ms, np, release)
+		if len(domains) != 1 {
+			t.Errorf("Expected domains to be of length 1, got '%d'", len(domains))
 		}
 
-		actualDomainURL := status.Domains[0].URL
+		actualDomainURL := domains[0].URL
 		expectedDomainURL := "https://my.cool.domain"
 		if actualDomainURL != expectedDomainURL {
 			t.Errorf("Expected domain URL to be %s, got '%s'", expectedDomainURL, actualDomainURL)
@@ -54,18 +54,18 @@ func TestNetworkStatus(t *testing.T) {
 			},
 		}
 
-		status, _ := buildNetworkStatusForRelease(ms, np, release)
-		if len(status.Domains) != 2 {
-			t.Errorf("Expected status domains to be of length 2, got '%d'", len(status.Domains))
+		domains, _ := buildNetworkStatusDomainsForRelease(ms, np, release)
+		if len(domains) != 2 {
+			t.Errorf("Expected domains to be of length 2, got '%d'", len(domains))
 		}
 
-		actualFirstDomainURL := status.Domains[0].URL
+		actualFirstDomainURL := domains[0].URL
 		expectedFirstDomainURL := "https://my.cool.domain"
 		if actualFirstDomainURL != expectedFirstDomainURL {
 			t.Errorf("Expected domain URL to be %s, got '%s'", expectedFirstDomainURL, actualFirstDomainURL)
 		}
 
-		actualSecondDomainURL := status.Domains[1].URL
+		actualSecondDomainURL := domains[1].URL
 		expectedSecondDomainURL := "https://my.other.cool.domain"
 		if actualSecondDomainURL != expectedSecondDomainURL {
 			t.Errorf("Expected domain URL to be %s, got '%s'", expectedSecondDomainURL, actualSecondDomainURL)
@@ -101,4 +101,60 @@ func TestFullDomain(t *testing.T) {
 			t.Errorf("Expected url to be '%s', got '%s'", url, actual)
 		}
 	})
+}
+
+func TestStatusDomainsEqual(t *testing.T) {
+	tcs := []struct {
+		name     string
+		old      []v1alpha1.Domain
+		new      []v1alpha1.Domain
+		expected bool
+	}{
+		{"empty (nil/nil)", nil, nil, true},
+		{"empty (nil/0)", nil, []v1alpha1.Domain{}, true},
+
+		{"one entry (equal)",
+			[]v1alpha1.Domain{{URL: "https://fake.fake"}},
+			[]v1alpha1.Domain{{URL: "https://fake.fake"}},
+			true,
+		},
+
+		{"one entry (equal with semver)",
+			[]v1alpha1.Domain{{URL: "https://fake.fake", SemVer: &v1alpha1.SemVerRelease{Name: "foo", Version: "0.1.0"}}},
+			[]v1alpha1.Domain{{URL: "https://fake.fake", SemVer: &v1alpha1.SemVerRelease{Name: "foo", Version: "0.1.0"}}},
+			true,
+		},
+
+		{"one entry (mismatched semver)",
+			[]v1alpha1.Domain{{URL: "https://fake.fake", SemVer: &v1alpha1.SemVerRelease{Name: "foo", Version: "0.1.0"}}},
+			[]v1alpha1.Domain{{URL: "https://fake.fake", SemVer: &v1alpha1.SemVerRelease{Name: "foo", Version: "0.1.1"}}},
+			false,
+		},
+
+		{"one entry (mismatched URL)",
+			[]v1alpha1.Domain{{URL: "https://fake.fake", SemVer: &v1alpha1.SemVerRelease{Name: "foo", Version: "0.1.0"}}},
+			[]v1alpha1.Domain{{URL: "https://anotherfake.fake", SemVer: &v1alpha1.SemVerRelease{Name: "foo", Version: "0.1.0"}}},
+			false,
+		},
+
+		{"two entries out of order",
+			[]v1alpha1.Domain{{URL: "https://fake.fake"}, {URL: "https://other.fake"}},
+			[]v1alpha1.Domain{{URL: "https://other.fake"}, {URL: "https://fake.fake"}},
+			true,
+		},
+
+		{"mismatched length",
+			[]v1alpha1.Domain{{URL: "https://fake.fake"}},
+			[]v1alpha1.Domain{{URL: "https://other.fake"}, {URL: "https://fake.fake"}},
+			false,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			if statusDomainsEqual(tc.old, tc.new) != tc.expected {
+				t.Error("bad result for statusDomainsEqual")
+			}
+		})
+	}
 }


### PR DESCRIPTION
Before, if there were multiple release groups, we'd update the
NetworkPolicyStatus once for each one, overwriting each other.

Instead, put them all into one status update. But before applying it, make
sure there is a change to the status, to prevent being affected by array
order changes.