### PR TITLE
Remove source ref from release struct

### DIFF
--- a/pkg/api/v1alpha1/release.go
+++ b/pkg/api/v1alpha1/release.go
@@ -26,9 +26,6 @@ type Release struct {
 	// SemVer is the SemVer release object linked to this Release if the
 	// VersioningPolicy associated with it is SemVer.
 	SemVer *SemVerRelease `json:"semVer,omitempty"`
-
-	// Source is where the release code comes from
-	Source *metav1.OwnerReference `json:"source"`
 }
 
 // String concatenates the Release values into a single unique string.

--- a/pkg/api/v1alpha1/zz_generated.go
+++ b/pkg/api/v1alpha1/zz_generated.go
@@ -1061,15 +1061,6 @@ func (in *Release) DeepCopyInto(out *Release) {
 			**out = **in
 		}
 	}
-	if in.Source != nil {
-		in, out := &in.Source, &out.Source
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(meta_v1.OwnerReference)
-			(*in).DeepCopyInto(*out)
-		}
-	}
 	return
 }
 

--- a/pkg/imagepolicy/controller.go
+++ b/pkg/imagepolicy/controller.go
@@ -214,13 +214,6 @@ func getVersioningPolicy(cl patchClient, ip *v1alpha1.ImagePolicy) (*v1alpha1.Ve
 
 // filter images available on the image policy status by release level and image registry tags
 func filterImages(image string, repo *v1alpha1.GitHubRepository, registry registry.Registry, vp *v1alpha1.VersioningPolicy) ([]v1alpha1.Release, error) {
-
-	// define the source as an OwnerReference
-	source := metav1.NewControllerRef(
-		repo,
-		v1alpha1.SchemeGroupVersion.WithKind(kubekit.TypeName(repo)),
-	)
-
 	releases := []v1alpha1.Release{}
 	for _, release := range repo.Status.Releases {
 
@@ -244,7 +237,6 @@ func filterImages(image string, repo *v1alpha1.GitHubRepository, registry regist
 			},
 			ReleaseTime: release.ReleaseTime,
 			Image:       image + ":" + release.Tag,
-			Source:      source,
 		}
 
 		releases = append(releases, confirmedRelease)

--- a/pkg/imagepolicy/controller_test.go
+++ b/pkg/imagepolicy/controller_test.go
@@ -6,12 +6,7 @@ import (
 
 	"github.com/manifoldco/heighliner/pkg/api/v1alpha1"
 	"k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-// registry mock
-// githubrespository mock
-// see if i can create a status that is populated with these things as I expect it
 
 func TestFilterImages(t *testing.T) {
 
@@ -78,8 +73,7 @@ func TestFilterImages(t *testing.T) {
 						Version: tc.tag,
 					},
 
-					Image:  "manifoldco/heighliner:" + tc.tag,
-					Source: &metav1.OwnerReference{},
+					Image: "manifoldco/heighliner:" + tc.tag,
 				},
 			}
 


### PR DESCRIPTION
This struct is in the status of imagepolicy and microservice.
Microservice references imagepolicy, and imagepolicy references the
github source, so we don't need this field.