### PR TITLE
Change the registry api to return a tag name

### DIFF
--- a/pkg/imagepolicy/controller_test.go
+++ b/pkg/imagepolicy/controller_test.go
@@ -91,6 +91,4 @@ func TestFilterImages(t *testing.T) {
 
 type mockRegistryClient struct{}
 
-func (c *mockRegistryClient) GetManifest(image string, tag string) (bool, error) {
-	return true, nil
-}
+func (c *mockRegistryClient) TagFor(image string, tag string) (string, error) { return tag, nil }

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -1,6 +1,24 @@
 package registry
 
+import "fmt"
+
 // Registry represents the interface any registry needs to provide to query it.
 type Registry interface {
-	GetManifest(string, string) (bool, error)
+	TagFor(string, string) (string, error)
+}
+
+type tagNotFoundError string
+
+func (t tagNotFoundError) Error() string { return string(t) }
+
+// NewTagNotFoundError returns an error that satisfies IsTagNotFoundError.
+func NewTagNotFoundError(repository, release string) error {
+	return tagNotFoundError(fmt.Sprintf("no suitable tag was found in '%s' for '%s'", repository, release))
+}
+
+// IsTagNotFoundError returns a bool indicating if the provided error is for
+// no matching tag being found.
+func IsTagNotFoundError(err error) bool {
+	_, ok := err.(tagNotFoundError)
+	return ok
 }

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -1,0 +1,24 @@
+package registry
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestIsTagNotFoundError(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		err := NewTagNotFoundError("arigato/beans", "1.0.0")
+
+		if !IsTagNotFoundError(err) {
+			t.Error("Error not reported as tag not found")
+		}
+	})
+
+	t.Run("not ok", func(t *testing.T) {
+		err := errors.New("fake")
+
+		if IsTagNotFoundError(err) {
+			t.Error("Error incorrectly reported as tag not found")
+		}
+	})
+}


### PR DESCRIPTION
This opens things up for us to select a tag name that doesn't match the
github release name.