### PR TITLE
Implement name based image policy matching

### DIFF
--- a/pkg/api/v1alpha1/image_policy.go
+++ b/pkg/api/v1alpha1/image_policy.go
@@ -1,9 +1,22 @@
 package v1alpha1
 
 import (
+	"bytes"
+	"errors"
+	"strings"
+	"text/template"
+
 	"k8s.io/api/core/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const defaultMatch = "{{.Tag}}"
+
+var (
+	errTagNotFound = errors.New("no Tag template value found")
+	errTooManyTags = errors.New("only one Tag template must be provided")
+	errNoMatch     = errors.New("no match found for from template")
 )
 
 // ImagePolicy describes the configuration options for the ImagePolicy.
@@ -31,6 +44,7 @@ type ImagePolicySpec struct {
 	ImagePullPolicy  *v1.PullPolicy            `json:"imagePullPolicy"`
 	VersioningPolicy v1.ObjectReference        `json:"versioningPolicy"`
 	Filter           ImagePolicyFilter         `json:"filter"`
+	Match            *ImagePolicyMatch         `json:"match,omitempty"`
 }
 
 // ImagePolicyStatus represents the latest version of the ImagePolicy that
@@ -39,6 +53,82 @@ type ImagePolicySpec struct {
 // Deployment.
 type ImagePolicyStatus struct {
 	Releases []Release `json:"releases"`
+}
+
+// ImagePolicyMatch defines how a release is matched to an image tag.
+type ImagePolicyMatch struct {
+	// Name defines a match on the image tag name.
+	Name *ImagePolicyMatchMapping `json:"name,omitempty"`
+}
+
+// ImagePolicyMatchMapping defines how a release is transformed to match an
+// image tag or label value
+type ImagePolicyMatchMapping struct {
+
+	// From transforms the release value, extracting the tag. The value is
+	// formatted as a Go template string, and matches on on `{{.Tag}}`. If no
+	// value is provided, "{{.Tag}}" is assumed.
+	From string `json:"from,omitempty"`
+
+	// To formats the extrated Tag value from From. If no value is provided,
+	// "{{.Tag}}" is assumed.
+	To string `json:"to,omitempty"`
+}
+
+// Map translates the provided from string to a to string. It returns an
+// error if either the configured From or To value cannot be compiled.
+func (m *ImagePolicyMatchMapping) Map(from string) (string, error) {
+	mfrom := m.From
+	if mfrom == "" {
+		mfrom = defaultMatch
+	}
+
+	parts := strings.Split(mfrom, defaultMatch)
+	switch len(parts) {
+	case 1:
+		return "", errTagNotFound
+	case 2: //ok
+	default:
+		return "", errTooManyTags
+	}
+
+	if parts[0] != "" {
+		newFrom := strings.TrimPrefix(from, parts[0])
+		if from == newFrom {
+			return "", errNoMatch
+		}
+		from = newFrom
+	}
+
+	if parts[1] != "" {
+		newFrom := strings.TrimSuffix(from, parts[1])
+		if from == newFrom {
+			return "", errNoMatch
+		}
+		from = newFrom
+	}
+
+	to := m.To
+	if to == "" {
+		to = defaultMatch
+	}
+
+	toT, err := template.New("").Parse(to)
+
+	if err != nil {
+		return "", err
+	}
+
+	w := &bytes.Buffer{}
+	if err := toT.Execute(w, struct{ Tag string }{from}); err != nil {
+		return "", err
+	}
+
+	if w.String() == m.To {
+		return "", errTagNotFound
+	}
+
+	return w.String(), nil
 }
 
 // ImagePolicyFilter will define how we can filter where images come from
@@ -56,6 +146,7 @@ var ImagePolicyValidationSchema = &v1beta1.CustomResourceValidation{
 				Required: []string{"image", "versioningPolicy", "filter"},
 				Properties: map[string]v1beta1.JSONSchemaProps{
 					"filter": filterValidationSchema,
+					"match":  matchValidationSchema,
 				},
 			},
 			"status": ReleaseValidationSchema,
@@ -68,5 +159,20 @@ var filterValidationSchema = v1beta1.JSONSchemaProps{
 		{
 			Required: []string{"github"},
 		},
+	},
+}
+
+var matchValidationSchema = v1beta1.JSONSchemaProps{
+	Type: "object",
+	Properties: map[string]v1beta1.JSONSchemaProps{
+		"name": mappingValidationSchema,
+	},
+}
+
+var mappingValidationSchema = v1beta1.JSONSchemaProps{
+	Type: "object",
+	Properties: map[string]v1beta1.JSONSchemaProps{
+		"from": {Type: "string"},
+		"to":   {Type: "string"},
 	},
 }

--- a/pkg/api/v1alpha1/image_policy_test.go
+++ b/pkg/api/v1alpha1/image_policy_test.go
@@ -1,0 +1,48 @@
+package v1alpha1
+
+import "testing"
+
+func TestImagePolicyMatchMapping(t *testing.T) {
+	tcs := []struct {
+		name  string
+		in    string
+		out   string
+		noErr bool
+
+		from string
+		to   string
+	}{
+		{"identity", "any", "any", true, "", ""},
+
+		{"map (from)", "v1.0.0", "1.0.0", true, "v{{.Tag}}", ""},
+		{"map (suffix)", "v1.0.0-thing", "1.0.0", true, "v{{.Tag}}-thing", ""},
+		{"map (to)", "1.0.0", "great-1.0.0-thing", true, "", "great-{{.Tag}}-thing"},
+		{"map (both)", "v1.0.0", "marketplace-1.0.0", true, "v{{.Tag}}", "marketplace-{{.Tag}}"},
+
+		{"no match in from", "1.0.0", "", false, "v{{.Tag}}", ""},
+
+		{"error (from / no template)", "any", "", false, "v", ""},
+		{"error (from / bad template)", "any", "", false, "{{.Tag", ""},
+		{"error (to / no template)", "any", "", false, "", "v"},
+		{"error (to / other template)", "any", "", false, "", "v{{.Food}}"},
+		{"error (to / bad template)", "any", "", false, "", "{{.Tag"},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			m := ImagePolicyMatchMapping{From: tc.from, To: tc.to}
+			out, err := m.Map(tc.in)
+			if tc.noErr && err != nil {
+				t.Fatal("expected no err but got one:", err)
+			}
+
+			if !tc.noErr && err == nil {
+				t.Fatal("expected err but got none.")
+			}
+
+			if out != tc.out {
+				t.Error("wrong mapping. expected:", tc.out, "got:", out)
+			}
+		})
+	}
+}

--- a/pkg/imagepolicy/controller.go
+++ b/pkg/imagepolicy/controller.go
@@ -128,7 +128,7 @@ func (c *Controller) syncPolicy(obj interface{}) error {
 		return nil
 	}
 
-	ip.Status.Releases, err = filterImages(ip.Spec.Image, repo, registry, vp)
+	ip.Status.Releases, err = filterImages(ip.Spec.Image, ip.Spec.Match, repo, registry, vp)
 	if err != nil {
 		log.Printf("Could not filter images for %s: %s", ip.Name, err)
 		return nil
@@ -218,7 +218,7 @@ func getVersioningPolicy(cl patchClient, ip *v1alpha1.ImagePolicy) (*v1alpha1.Ve
 }
 
 // filter images available on the image policy status by release level and image registry tags
-func filterImages(image string, repo *v1alpha1.GitHubRepository, reg registry.Registry, vp *v1alpha1.VersioningPolicy) ([]v1alpha1.Release, error) {
+func filterImages(image string, matcher *v1alpha1.ImagePolicyMatch, repo *v1alpha1.GitHubRepository, reg registry.Registry, vp *v1alpha1.VersioningPolicy) ([]v1alpha1.Release, error) {
 	releases := []v1alpha1.Release{}
 	for _, release := range repo.Status.Releases {
 
@@ -226,7 +226,7 @@ func filterImages(image string, repo *v1alpha1.GitHubRepository, reg registry.Re
 			continue
 		}
 
-		tag, err := reg.TagFor(image, release.Tag)
+		tag, err := reg.TagFor(image, release.Tag, matcher)
 		if registry.IsTagNotFoundError(err) {
 			log.Printf("Release %s for tag %s is not available in the registry", release.Name, release.Tag)
 			continue

--- a/pkg/imagepolicy/controller_test.go
+++ b/pkg/imagepolicy/controller_test.go
@@ -77,7 +77,7 @@ func TestFilterImages(t *testing.T) {
 				},
 			}
 
-			actualReleases, err := filterImages(ip.Spec.Image, repo, registry, vp)
+			actualReleases, err := filterImages(ip.Spec.Image, ip.Spec.Match, repo, registry, vp)
 			if err != nil {
 				t.Errorf("Error filtering images for %s", ip.Name)
 			}
@@ -91,4 +91,6 @@ func TestFilterImages(t *testing.T) {
 
 type mockRegistryClient struct{}
 
-func (c *mockRegistryClient) TagFor(image string, tag string) (string, error) { return tag, nil }
+func (c *mockRegistryClient) TagFor(image string, tag string, matcher *v1alpha1.ImagePolicyMatch) (string, error) {
+	return tag, nil
+}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -1,10 +1,13 @@
 package registry
 
-import "fmt"
+import (
+	"fmt"
+	"github.com/manifoldco/heighliner/pkg/api/v1alpha1"
+)
 
 // Registry represents the interface any registry needs to provide to query it.
 type Registry interface {
-	TagFor(string, string) (string, error)
+	TagFor(string, string, *v1alpha1.ImagePolicyMatch) (string, error)
 }
 
 type tagNotFoundError string


### PR DESCRIPTION
We can now define a match field on the image policy to transform a
github release value into the value we expect as a docker tag. The value
defaults to as it was before, just using the exact value.