### PR TITLE
Image policy label matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+- Introduce an optional `match` field for ImagePolicy to control how releases
+  map to container images, based on container image tag name, labels, or both.
+
 ## v0.1.0
 
 Docker Image: [arigato/heighliner:0.1.0](https://hub.docker.com/r/arigato/heighliner/tags)

--- a/_examples/image-policy-match.yaml
+++ b/_examples/image-policy-match.yaml
@@ -1,0 +1,73 @@
+# These ImagePolicies demonstrate how to use the `match` field to select
+# container images.
+# All examples here assume the Secret and VersioningPolicy from
+# `image-policy.yaml` exist.
+
+# This is the default match configuration. If no value is set, Heighliner
+# attempts to find tags in the container registry that have the same name
+# as any GitHub releases that have passed through the VersioningPolicy.
+apiVersion: hlnr.io/v1alpha1
+kind: ImagePolicy
+metadata:
+  name: default-match
+spec:
+  image: your/demo-application
+  imagePullSecrets:
+  - name: docker-registry
+  versioningPolicy:
+    name: previews
+  filter:
+    github:
+      name: demo-application
+  match:
+    name:
+      from: "{{.Tag}}"
+      to: "{{.Tag}}"
+
+---
+
+# This configuration uses pattern matching and templating. Heighliner will
+# find a release with the tag `v1.0.0` (for example) and match it to a tag in the
+# container registry with the value `cool-1.0.0`.
+apiVersion: hlnr.io/v1alpha1
+kind: ImagePolicy
+metadata:
+  name: convert-name
+spec:
+  image: your/demo-application
+  imagePullSecrets:
+  - name: docker-registry
+  versioningPolicy:
+    name: previews
+  filter:
+    github:
+      name: demo-application
+  match:
+    name:
+      from: "v{{.Tag}}"
+      to: "cool-{{.Tag}}"
+
+---
+
+# This configuration uses label matching. You can match on any number of lables,
+# with or without name. If a given label does not exist on a container image,
+# it will not match.
+#
+# If a match value is the empty object `{}`, it is treated as an identity
+# mapping, as in the default value.
+apiVersion: hlnr.io/v1alpha1
+kind: ImagePolicy
+metadata:
+  name: convert-name
+spec:
+  image: your/demo-application
+  imagePullSecrets:
+  - name: docker-registry
+  versioningPolicy:
+    name: previews
+  filter:
+    github:
+      name: demo-application
+  match:
+    labels:
+      org.me.my-tag-label: {}

--- a/apis/v1alpha1/image_policy.go
+++ b/apis/v1alpha1/image_policy.go
@@ -63,6 +63,9 @@ type ImagePolicyStatus struct {
 type ImagePolicyMatch struct {
 	// Name defines a match on the image tag name.
 	Name *ImagePolicyMatchMapping `json:"name,omitempty"`
+
+	// Labels defines matches on image labels.
+	Labels map[string]ImagePolicyMatchMapping `json:"labels,omitempty"`
 }
 
 // MapName returns the Name mapping for the provided release value.
@@ -74,6 +77,46 @@ func (m *ImagePolicyMatch) MapName(release string) (string, error) {
 
 	mapped, err := m.Name.Map(release)
 	return mapped, err
+}
+
+// Matches returns a bool indicating if the provided image tag and labels match
+// this match stanza. It returns an error if any of the match mappings error.
+// If m is nil or the zero value, it uses the default match value of:
+//   match:
+//     name:
+//       from: "{{.Tag}}"
+//       to: "{{.Tag}}"
+func (m *ImagePolicyMatch) Matches(release, tag string, labels map[string]string) (bool, error) {
+	if m == nil || (m.Name == nil && len(m.Labels) == 0) {
+		m = defaultImagePolicyMatch
+	}
+
+	if m.Name != nil {
+		mapped, err := m.Name.Map(release)
+		if err != nil {
+			return false, err
+		}
+		if mapped != tag {
+			return false, nil
+		}
+	}
+
+	for l, lm := range m.Labels {
+		t, ok := labels[l]
+		if !ok {
+			return false, nil
+		}
+
+		mapped, err := lm.Map(release)
+		if err != nil {
+			return false, err
+		}
+		if mapped != t {
+			return false, nil
+		}
+	}
+
+	return true, nil
 }
 
 // ImagePolicyMatchMapping defines how a release is transformed to match an
@@ -181,6 +224,12 @@ var matchValidationSchema = v1beta1.JSONSchemaProps{
 	Type: "object",
 	Properties: map[string]v1beta1.JSONSchemaProps{
 		"name": mappingValidationSchema,
+		"labels": {
+			Type: "object",
+			AdditionalProperties: &v1beta1.JSONSchemaPropsOrBool{
+				Schema: &mappingValidationSchema,
+			},
+		},
 	},
 }
 

--- a/apis/v1alpha1/image_policy.go
+++ b/apis/v1alpha1/image_policy.go
@@ -68,6 +68,16 @@ type ImagePolicyMatch struct {
 	Labels map[string]ImagePolicyMatchMapping `json:"labels,omitempty"`
 }
 
+// Config returns two booleans indicating if there is name matching and label
+// matching in this match.
+func (m *ImagePolicyMatch) Config() (bool, bool) {
+	if m == nil || (m.Name == nil && len(m.Labels) == 0) {
+		m = defaultImagePolicyMatch
+	}
+
+	return m.Name != nil, len(m.Labels) > 0
+}
+
 // MapName returns the Name mapping for the provided release value.
 // It returns an error if the name mapping errors.
 func (m *ImagePolicyMatch) MapName(release string) (string, error) {

--- a/apis/v1alpha1/image_policy_test.go
+++ b/apis/v1alpha1/image_policy_test.go
@@ -2,6 +2,42 @@ package v1alpha1
 
 import "testing"
 
+func TestImagePolicyMatchConfig(t *testing.T) {
+	tcs := []struct {
+		name string
+
+		hasName   bool
+		hasLabels bool
+
+		match *ImagePolicyMatch
+	}{
+		{"nil", true, false, nil},
+		{"empty", true, false, &ImagePolicyMatch{}},
+
+		{"both", true, true, &ImagePolicyMatch{
+			Name: &ImagePolicyMatchMapping{},
+			Labels: map[string]ImagePolicyMatchMapping{
+				"org.fake.label": {},
+			},
+		}},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+
+			n, l := tc.match.Config()
+
+			if n != tc.hasName {
+				t.Error("wrong value for name. expected:", tc.hasName, "got:", n)
+			}
+
+			if l != tc.hasLabels {
+				t.Error("wrong value for labels. expected:", tc.hasLabels, "got:", l)
+			}
+		})
+	}
+}
+
 func TestImagePolicyMatchMapName(t *testing.T) {
 	tcs := []struct {
 		name string

--- a/docs/design/image-policy.md
+++ b/docs/design/image-policy.md
@@ -7,6 +7,13 @@ ImagePolicies have Filters, these filters define where the releases will come
 from. The ImagePolicy is then responsible for validating that the desired images
 are available in the linked registry.
 
+ImagePolicies can optionally define a match configuration. Match is used to
+control how GitHub releases map to container registry images. By defaut, the
+release name is directly mapped to an image tag name. You can use `from` and
+`to` values to do pattern matching on the GitHub release, and templating to
+match container image tags. You can also define container image labels to match
+on in the same way.
+
 The ImagePolicy also matches the releases with the Versioning Policy, this means
 that there could be multiple releases available, but the ImagePolicy will filter
 these out further to only select the ones that match the VersioningPolicy.


### PR DESCRIPTION
The image policy match section can now optionally support a labels
field, which, if specified, takes a series of image labels.

If any are supplied, all labels must exist on an image, and the value
must match the mapping, for an image to match. Both a name match and
label matches can be specified. Multiple label matches can be specified.

With label matching, we may or may not know the image tag we're looking
for, so update the logic to account for that, and optionally fetch image
labels, if we need to match on them.