### PR TITLE
Add Health Check for the GH Callback Server.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+
+- Added a health check for the GitHub Callback Server.
+- Added logging to indicate GH Callback Server requests.
+
 ## [0.1.2] - 2018-07-16
 
 ### Fixed

--- a/docs/kube/github-policy.yaml
+++ b/docs/kube/github-policy.yaml
@@ -72,6 +72,18 @@ spec:
             requests:
               cpu: 100m
               memory: 10Mi
+          readinessProbe:
+            httpGet:
+              path: /_healthz
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          livenessProbe:
+            httpGet:
+              path: /_healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 3
 
 ---
 

--- a/internal/githubrepository/callbacks.go
+++ b/internal/githubrepository/callbacks.go
@@ -66,6 +66,7 @@ type callbackHook struct {
 func (s *callbackServer) start(address string) {
 	hdlr := mux.NewRouter()
 	hdlr.HandleFunc("/payload/{owner}/{name}", s.payloadHandler)
+	hdlr.HandleFunc("/_healtz", s.healthzHandler)
 
 	s.srv = &http.Server{
 		Handler:      hdlr,
@@ -82,6 +83,11 @@ func (s *callbackServer) start(address string) {
 
 func (s *callbackServer) stop(ctx context.Context) error {
 	return s.srv.Shutdown(ctx)
+}
+
+func (s *callbackServer) healthzHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("OK!"))
 }
 
 func (s *callbackServer) payloadHandler(w http.ResponseWriter, r *http.Request) {

--- a/internal/githubrepository/callbacks.go
+++ b/internal/githubrepository/callbacks.go
@@ -92,8 +92,11 @@ func (s *callbackServer) healthzHandler(w http.ResponseWriter, r *http.Request) 
 
 func (s *callbackServer) payloadHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
+	log.Printf("Handling payload for %s/%s", vars["owner"], vars["name"])
+
 	cbHook, ok := s.hookForRepo(vars["owner"], vars["name"])
 	if !ok {
+		log.Printf("No repository found for %s/%s", vars["owner"], vars["name"])
 		w.WriteHeader(http.StatusNotFound)
 		w.Write([]byte("404 Not Found"))
 		return
@@ -101,6 +104,7 @@ func (s *callbackServer) payloadHandler(w http.ResponseWriter, r *http.Request) 
 
 	payload, err := github.ValidatePayload(r, []byte(cbHook.hook.Secret))
 	if err != nil {
+		log.Printf("Could not validate payload for %s/%s: %s", vars["owner"], vars["name"], err)
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return


### PR DESCRIPTION
By adding a Health Check to the Callback Server we ensure that the server is
available at all times. If this isn't the case, Kubernetes will take care of
restarting the controller.

This also adds logging so we get an indication if a callback reaches our
server or not.