### PR TITLE
Add missing watch verb for gh

### DIFF
--- a/docs/kube/github-policy.yaml
+++ b/docs/kube/github-policy.yaml
@@ -12,7 +12,7 @@ rules:
     - "microservices"
     - "networkpolicies"
     - "imagepolicies"
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["*"]


### PR DESCRIPTION
Fix the following issue when using RBAC:

```
E0905 13:36:52.470401       1 reflector.go:322] github.com/manifoldco/heighliner/vendor/github.com/jelmersnoeck/kubekit/watcher.go:53: Failed to watch *v1alpha1.NetworkPolicy: unknown (get networkpolicies.hlnr.io)
```