### PR TITLE
Correct Group for Ingress Service OwnerReference.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ spec:
 ### Fixed
 
 - Fixed the Makefile target for generating files.
+- Fixed a bug where the OwnerReference on a Ingress for the Service pointed to the wrong APIGroup.
 
 ## [0.1.2] - 2018-07-16
 

--- a/internal/networkpolicy/ingress.go
+++ b/internal/networkpolicy/ingress.go
@@ -6,9 +6,12 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/jelmersnoeck/kubekit"
 	"github.com/manifoldco/heighliner/apis/v1alpha1"
 	"github.com/manifoldco/heighliner/internal/meta"
+
+	"github.com/jelmersnoeck/kubekit"
+
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -70,7 +73,7 @@ func buildIngressForRelease(ms *v1alpha1.Microservice, np *v1alpha1.NetworkPolic
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(
 					srv,
-					v1alpha1.SchemeGroupVersion.WithKind(kubekit.TypeName(srv)),
+					corev1.SchemeGroupVersion.WithKind(kubekit.TypeName(srv)),
 				),
 			},
 		},

--- a/internal/networkpolicy/ingress_test.go
+++ b/internal/networkpolicy/ingress_test.go
@@ -1,8 +1,10 @@
 package networkpolicy
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/jelmersnoeck/kubekit"
 	"github.com/manifoldco/heighliner/apis/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,12 +53,13 @@ func TestBuildIngressForRelease(t *testing.T) {
 			t.Error("Wrong number of owners:", len(ing.OwnerReferences))
 		}
 
-		if ing.OwnerReferences[0].Name != srv.Name ||
-			ing.OwnerReferences[0].Kind != srv.Kind ||
-			ing.OwnerReferences[0].Controller == nil ||
-			!*ing.OwnerReferences[0].Controller {
+		ownerReference := *metav1.NewControllerRef(
+			srv,
+			corev1.SchemeGroupVersion.WithKind(kubekit.TypeName(srv)),
+		)
 
-			t.Error("Bad OwnerReference seen. got", ing.OwnerReferences)
+		if !reflect.DeepEqual(ing.OwnerReferences[0], ownerReference) {
+			t.Errorf("Bad OwnerReference seen. got\n%#v\n\nwanted\n%#v", ing.OwnerReferences[0], ownerReference)
 		}
 	})
 


### PR DESCRIPTION
The APIGroup was set to the hlnr.io group. We want it to be the corev1
group so it actually references the correct items.