### PR TITLE
Encapsulate manifold run.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,18 +18,18 @@ branches:
   - master
   - "/^v([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:\\-(rc\\.[0-9]+)*)?$/"
 script:
-- manifold run -- make ci
+- make ci
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 deploy:
 - provider: script
-  script: make release
+  script: manifold run -- make release
   skip_cleanup: true
   on:
     branch: master
     repo: manifoldco/heighliner
 - provider: script
-  script: make release
+  script: manifold run -- make release
   skip_cleanup: true
   on:
     tags: true


### PR DESCRIPTION
Manifold Run doesn't work on PRs due to Travis' set up with regards to
secrets.

Manifold Run is only needed when we release the image - to inject the
docker credentials. We don't need to do this when we run tests and
linting.

Let's move it to only run when we build the images (after merging a PR)
so that we can ensure PRs still build.